### PR TITLE
ose.conf parser

### DIFF
--- a/groups/openshift-3.3/aos-f5-router-docker/config.yml
+++ b/groups/openshift-3.3/aos-f5-router-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/router/f5
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and programs
+    a BigIP F5 router to expose services within the cluster.
+  io.k8s.display-name: OpenShift Container Platform F5 Router
+  io.openshift.tags: openshift,router,f5
+  vendor: Red Hat
+name: openshift3/ose-f5-router
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.3/aos3-installation-docker/config.yml
+++ b/groups/openshift-3.3/aos3-installation-docker/config.yml
@@ -1,0 +1,19 @@
+content:
+  source:
+    alias: openshift-ansible
+    path: images/installer
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Ansible code and playbooks for installing Openshift Container
+    Platform.
+  io.k8s.display-name: Openshift Installer
+  io.openshift.tags: openshift,installer
+  vendor: Red Hat
+name: openshift3/ose-ansible
+owners:
+- tdawson@redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.3/logging-curator-docker/config.yml
+++ b/groups/openshift-3.3/logging-curator-docker/config.yml
@@ -1,0 +1,14 @@
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Curator elasticsearch container for elasticsearch deletion/archival
+  io.k8s.display-name: Curator 3.5.1
+  io.openshift.tags: logging,elk,elasticsearch,curator
+  vendor: Red Hat
+name: openshift3/logging-curator
+owners:
+- dev@lists.openshift.redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.3/logging-deployment-docker/config.yml
+++ b/groups/openshift-3.3/logging-deployment-docker/config.yml
@@ -1,0 +1,14 @@
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Deployer container for deploying the aggregated logging solution
+  io.k8s.display-name: Logging deployer
+  io.openshift.tags: logging,elk,fluentd
+  vendor: Red Hat
+name: openshift3/logging-deployer
+owners:
+- dev@lists.openshift.redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.3/metrics-deployer-docker/config.yml
+++ b/groups/openshift-3.3/metrics-deployer-docker/config.yml
@@ -1,0 +1,13 @@
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Image to handle deploying all the metrics components.
+  io.k8s.display-name: Metrics Deployer
+  io.openshift.tags: metrics,deployer
+  vendor: Red Hat
+name: openshift3/metrics-deployer
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.3/openshift-enterprise-base-docker/config.yml
+++ b/groups/openshift-3.3/openshift-enterprise-base-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/base
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is the base image from which all OpenShift Container Platform
+    images inherit.
+  io.k8s.display-name: OpenShift Container Platform RHEL 7 Base
+  io.openshift.tags: openshift,base
+  vendor: Red Hat
+name: openshift3/ose-base
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.3/openshift-enterprise-deployer-docker/config.yml
+++ b/groups/openshift-3.3/openshift-enterprise-deployer-docker/config.yml
@@ -1,0 +1,19 @@
+content:
+  source:
+    alias: ose
+    path: images/deployer
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and executes
+    the user deployment process to roll out new containers. It may be used as a base
+    image for building your own custom deployer image.
+  io.k8s.display-name: OpenShift Container Platform Deployer
+  io.openshift.tags: openshift,deployer
+  vendor: Red Hat
+name: openshift3/ose-deployer
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.3/openshift-enterprise-docker-builder-docker/config.yml
+++ b/groups/openshift-3.3/openshift-enterprise-docker-builder-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/builder/docker/docker-builder
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and is responsible
+    for executing Docker image builds.
+  io.k8s.display-name: OpenShift Container Platform Docker Builder
+  io.openshift.tags: openshift,builder
+  vendor: Red Hat
+name: openshift3/ose-docker-builder
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.3/openshift-enterprise-docker/config.yml
+++ b/groups/openshift-3.3/openshift-enterprise-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/origin
+from:
+  member: openshift-enterprise-base-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: OpenShift Container Platform is a platform for developing, building,
+    and deploying containerized applications.
+  io.k8s.display-name: OpenShift Container Platform Application Platform
+  io.openshift.tags: openshift,core
+  vendor: Red Hat
+name: openshift3/ose
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.3/openshift-enterprise-dockerregistry-docker/config.yml
+++ b/groups/openshift-3.3/openshift-enterprise-dockerregistry-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/dockerregistry
+from:
+  member: openshift-enterprise-base-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component ofOpenShift Container Platform and exposes
+    a Docker registry that is integrated with the cluster for authentication and management.
+  io.k8s.display-name: OpenShift Container Platform Image Registry
+  io.openshift.tags: openshift,docker,registry
+  vendor: Red Hat
+name: openshift3/ose-docker-registry
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.3/openshift-enterprise-egress-router-docker/config.yml
+++ b/groups/openshift-3.3/openshift-enterprise-egress-router-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/egress/router
+from:
+  member: openshift-enterprise-base-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and contains
+    an egress router.
+  io.k8s.display-name: OpenShift Container Platform Egress Router
+  io.openshift.tags: openshift,router,egress
+  vendor: Red Hat
+name: openshift3/ose-egress-router
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.3/openshift-enterprise-haproxy-router-docker/config.yml
+++ b/groups/openshift-3.3/openshift-enterprise-haproxy-router-docker/config.yml
@@ -1,0 +1,20 @@
+content:
+  source:
+    alias: ose
+    path: images/router/haproxy
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and contains
+    an HAProxy instance that automatically exposes services within the cluster through
+    routes, and offers TLS termination, reencryption, or SNI-passthrough on ports
+    80 and 443.
+  io.k8s.display-name: OpenShift Container Platform HAProxy Router
+  io.openshift.tags: openshift,router,haproxy
+  vendor: Red Hat
+name: openshift3/ose-haproxy-router
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.3/openshift-enterprise-keepalived-ipfailover-docker/config.yml
+++ b/groups/openshift-3.3/openshift-enterprise-keepalived-ipfailover-docker/config.yml
@@ -1,0 +1,19 @@
+content:
+  source:
+    alias: ose
+    path: images/ipfailover/keepalived
+from:
+  member: openshift-enterprise-base-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and runs
+    a clustered keepalived instance across multiple hosts to allow highly available
+    IP addresses.
+  io.k8s.display-name: OpenShift Container Platform IP Failover
+  io.openshift.tags: openshift,ha,ip,failover
+  vendor: Red Hat
+name: openshift3/ose-keepalived-ipfailover
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.3/openshift-enterprise-node-docker/config.yml
+++ b/groups/openshift-3.3/openshift-enterprise-node-docker/config.yml
@@ -1,0 +1,19 @@
+content:
+  source:
+    alias: ose
+    path: images/node
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and contains
+    the software for individual nodes when using SDN.
+  io.k8s.display-name: OpenShift Container Platform Node
+  io.openshift.tags: openshift,node
+  vendor: Red Hat
+name: openshift3/node
+owners:
+- dgoodwin@redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.3/openshift-enterprise-openvswitch-docker/config.yml
+++ b/groups/openshift-3.3/openshift-enterprise-openvswitch-docker/config.yml
@@ -1,0 +1,19 @@
+content:
+  source:
+    alias: ose
+    path: images/openvswitch
+from:
+  member: openshift-enterprise-node-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and runs
+    an OpenVSwitch daemon process.
+  io.k8s.display-name: OpenShift Container Platform OpenVSwitch Daemon
+  io.openshift.tags: openshift,openvswitch
+  vendor: Red Hat
+name: openshift3/openvswitch
+owners:
+- sdodson@redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.3/openshift-enterprise-pod-docker/config.yml
+++ b/groups/openshift-3.3/openshift-enterprise-pod-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/pod
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and holds
+    on to the shared Linux namespaces within a Pod.
+  io.k8s.display-name: OpenShift Container Platform Pod Infrastructure
+  io.openshift.tags: openshift,pod
+  vendor: Red Hat
+name: openshift3/ose-pod rhel7/pod-infrastructure
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.3/openshift-enterprise-recycler-docker/config.yml
+++ b/groups/openshift-3.3/openshift-enterprise-recycler-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/recycler
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and is used
+    to prepare persistent volumes for reuse after they are deleted.
+  io.k8s.display-name: OpenShift Container Platform Volume Recycler
+  io.openshift.tags: openshift,recycler
+  vendor: Red Hat
+name: openshift3/ose-recycler
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.3/openshift-enterprise-sti-builder-docker/config.yml
+++ b/groups/openshift-3.3/openshift-enterprise-sti-builder-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/builder/docker/sti-builder
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and is responsible
+    for executing source-to-image (s2i) image builds.
+  io.k8s.display-name: OpenShift Container Platform S2I Builder
+  io.openshift.tags: openshift,sti,builder
+  vendor: Red Hat
+name: openshift3/ose-sti-builder
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.4/aos-f5-router-docker/config.yml
+++ b/groups/openshift-3.4/aos-f5-router-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/router/f5
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and programs
+    a BigIP F5 router to expose services within the cluster.
+  io.k8s.display-name: OpenShift Container Platform F5 Router
+  io.openshift.tags: openshift,router,f5
+  vendor: Red Hat
+name: openshift3/ose-f5-router
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.4/aos3-installation-docker/config.yml
+++ b/groups/openshift-3.4/aos3-installation-docker/config.yml
@@ -1,0 +1,19 @@
+content:
+  source:
+    alias: openshift-ansible
+    path: images/installer
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Ansible code and playbooks for installing Openshift Container
+    Platform.
+  io.k8s.display-name: Openshift Installer
+  io.openshift.tags: openshift,installer
+  vendor: Red Hat
+name: openshift3/ose-ansible
+owners:
+- tdawson@redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.4/logging-curator-docker/config.yml
+++ b/groups/openshift-3.4/logging-curator-docker/config.yml
@@ -1,0 +1,14 @@
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Curator elasticsearch container for elasticsearch deletion/archival
+  io.k8s.display-name: Curator 3.5.1
+  io.openshift.tags: logging,elk,elasticsearch,curator
+  vendor: Red Hat
+name: openshift3/logging-curator
+owners:
+- dev@lists.openshift.redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.4/logging-deployment-docker/config.yml
+++ b/groups/openshift-3.4/logging-deployment-docker/config.yml
@@ -1,0 +1,14 @@
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Deployer container for deploying the aggregated logging solution
+  io.k8s.display-name: Logging deployer
+  io.openshift.tags: logging,elk,fluentd
+  vendor: Red Hat
+name: openshift3/logging-deployer
+owners:
+- dev@lists.openshift.redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.4/metrics-deployer-docker/config.yml
+++ b/groups/openshift-3.4/metrics-deployer-docker/config.yml
@@ -1,0 +1,13 @@
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Image to handle deploying all the metrics components.
+  io.k8s.display-name: Metrics Deployer
+  io.openshift.tags: metrics,deployer
+  vendor: Red Hat
+name: openshift3/metrics-deployer
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.4/openshift-enterprise-base-docker/config.yml
+++ b/groups/openshift-3.4/openshift-enterprise-base-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/base
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is the base image from which all OpenShift Container Platform
+    images inherit.
+  io.k8s.display-name: OpenShift Container Platform RHEL 7 Base
+  io.openshift.tags: openshift,base
+  vendor: Red Hat
+name: openshift3/ose-base
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.4/openshift-enterprise-deployer-docker/config.yml
+++ b/groups/openshift-3.4/openshift-enterprise-deployer-docker/config.yml
@@ -1,0 +1,19 @@
+content:
+  source:
+    alias: ose
+    path: images/deployer
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and executes
+    the user deployment process to roll out new containers. It may be used as a base
+    image for building your own custom deployer image.
+  io.k8s.display-name: OpenShift Container Platform Deployer
+  io.openshift.tags: openshift,deployer
+  vendor: Red Hat
+name: openshift3/ose-deployer
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.4/openshift-enterprise-docker-builder-docker/config.yml
+++ b/groups/openshift-3.4/openshift-enterprise-docker-builder-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/builder/docker/docker-builder
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and is responsible
+    for executing Docker image builds.
+  io.k8s.display-name: OpenShift Container Platform Docker Builder
+  io.openshift.tags: openshift,builder
+  vendor: Red Hat
+name: openshift3/ose-docker-builder
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.4/openshift-enterprise-docker/config.yml
+++ b/groups/openshift-3.4/openshift-enterprise-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/origin
+from:
+  member: openshift-enterprise-base-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: OpenShift Container Platform is a platform for developing, building,
+    and deploying containerized applications.
+  io.k8s.display-name: OpenShift Container Platform Application Platform
+  io.openshift.tags: openshift,core
+  vendor: Red Hat
+name: openshift3/ose
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.4/openshift-enterprise-dockerregistry-docker/config.yml
+++ b/groups/openshift-3.4/openshift-enterprise-dockerregistry-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/dockerregistry
+from:
+  member: openshift-enterprise-base-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component ofOpenShift Container Platform and exposes
+    a Docker registry that is integrated with the cluster for authentication and management.
+  io.k8s.display-name: OpenShift Container Platform Image Registry
+  io.openshift.tags: openshift,docker,registry
+  vendor: Red Hat
+name: openshift3/ose-docker-registry
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.4/openshift-enterprise-egress-router-docker/config.yml
+++ b/groups/openshift-3.4/openshift-enterprise-egress-router-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/egress/router
+from:
+  member: openshift-enterprise-base-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and contains
+    an egress router.
+  io.k8s.display-name: OpenShift Container Platform Egress Router
+  io.openshift.tags: openshift,router,egress
+  vendor: Red Hat
+name: openshift3/ose-egress-router
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.4/openshift-enterprise-haproxy-router-docker/config.yml
+++ b/groups/openshift-3.4/openshift-enterprise-haproxy-router-docker/config.yml
@@ -1,0 +1,20 @@
+content:
+  source:
+    alias: ose
+    path: images/router/haproxy
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and contains
+    an HAProxy instance that automatically exposes services within the cluster through
+    routes, and offers TLS termination, reencryption, or SNI-passthrough on ports
+    80 and 443.
+  io.k8s.display-name: OpenShift Container Platform HAProxy Router
+  io.openshift.tags: openshift,router,haproxy
+  vendor: Red Hat
+name: openshift3/ose-haproxy-router
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.4/openshift-enterprise-keepalived-ipfailover-docker/config.yml
+++ b/groups/openshift-3.4/openshift-enterprise-keepalived-ipfailover-docker/config.yml
@@ -1,0 +1,19 @@
+content:
+  source:
+    alias: ose
+    path: images/ipfailover/keepalived
+from:
+  member: openshift-enterprise-base-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and runs
+    a clustered keepalived instance across multiple hosts to allow highly available
+    IP addresses.
+  io.k8s.display-name: OpenShift Container Platform IP Failover
+  io.openshift.tags: openshift,ha,ip,failover
+  vendor: Red Hat
+name: openshift3/ose-keepalived-ipfailover
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.4/openshift-enterprise-node-docker/config.yml
+++ b/groups/openshift-3.4/openshift-enterprise-node-docker/config.yml
@@ -1,0 +1,19 @@
+content:
+  source:
+    alias: ose
+    path: images/node
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and contains
+    the software for individual nodes when using SDN.
+  io.k8s.display-name: OpenShift Container Platform Node
+  io.openshift.tags: openshift,node
+  vendor: Red Hat
+name: openshift3/node
+owners:
+- dgoodwin@redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.4/openshift-enterprise-openvswitch-docker/config.yml
+++ b/groups/openshift-3.4/openshift-enterprise-openvswitch-docker/config.yml
@@ -1,0 +1,19 @@
+content:
+  source:
+    alias: ose
+    path: images/openvswitch
+from:
+  member: openshift-enterprise-node-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and runs
+    an OpenVSwitch daemon process.
+  io.k8s.display-name: OpenShift Container Platform OpenVSwitch Daemon
+  io.openshift.tags: openshift,openvswitch
+  vendor: Red Hat
+name: openshift3/openvswitch
+owners:
+- sdodson@redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.4/openshift-enterprise-pod-docker/config.yml
+++ b/groups/openshift-3.4/openshift-enterprise-pod-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/pod
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and holds
+    on to the shared Linux namespaces within a Pod.
+  io.k8s.display-name: OpenShift Container Platform Pod Infrastructure
+  io.openshift.tags: openshift,pod
+  vendor: Red Hat
+name: openshift3/ose-pod rhel7/pod-infrastructure
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.4/openshift-enterprise-recycler-docker/config.yml
+++ b/groups/openshift-3.4/openshift-enterprise-recycler-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/recycler
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and is used
+    to prepare persistent volumes for reuse after they are deleted.
+  io.k8s.display-name: OpenShift Container Platform Volume Recycler
+  io.openshift.tags: openshift,recycler
+  vendor: Red Hat
+name: openshift3/ose-recycler
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.4/openshift-enterprise-sti-builder-docker/config.yml
+++ b/groups/openshift-3.4/openshift-enterprise-sti-builder-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/builder/docker/sti-builder
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and is responsible
+    for executing source-to-image (s2i) image builds.
+  io.k8s.display-name: OpenShift Container Platform S2I Builder
+  io.openshift.tags: openshift,sti,builder
+  vendor: Red Hat
+name: openshift3/ose-sti-builder
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.5/aos-f5-router-docker/config.yml
+++ b/groups/openshift-3.5/aos-f5-router-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/router/f5
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and programs
+    a BigIP F5 router to expose services within the cluster.
+  io.k8s.display-name: OpenShift Container Platform F5 Router
+  io.openshift.tags: openshift,router,f5
+  vendor: Red Hat
+name: openshift3/ose-f5-router
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.5/aos3-installation-docker/config.yml
+++ b/groups/openshift-3.5/aos3-installation-docker/config.yml
@@ -1,0 +1,19 @@
+content:
+  source:
+    alias: openshift-ansible
+    path: images/installer
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Ansible code and playbooks for installing Openshift Container
+    Platform.
+  io.k8s.display-name: Openshift Installer
+  io.openshift.tags: openshift,installer
+  vendor: Red Hat
+name: openshift3/ose-ansible
+owners:
+- tdawson@redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.5/logging-curator-docker/config.yml
+++ b/groups/openshift-3.5/logging-curator-docker/config.yml
@@ -1,0 +1,14 @@
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Curator elasticsearch container for elasticsearch deletion/archival
+  io.k8s.display-name: Curator 3.5.1
+  io.openshift.tags: logging,elk,elasticsearch,curator
+  vendor: Red Hat
+name: openshift3/logging-curator
+owners:
+- dev@lists.openshift.redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.5/logging-deployment-docker/config.yml
+++ b/groups/openshift-3.5/logging-deployment-docker/config.yml
@@ -1,0 +1,14 @@
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Deployer container for deploying the aggregated logging solution
+  io.k8s.display-name: Logging deployer
+  io.openshift.tags: logging,elk,fluentd
+  vendor: Red Hat
+name: openshift3/logging-deployer
+owners:
+- dev@lists.openshift.redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.5/metrics-deployer-docker/config.yml
+++ b/groups/openshift-3.5/metrics-deployer-docker/config.yml
@@ -1,0 +1,13 @@
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Image to handle deploying all the metrics components.
+  io.k8s.display-name: Metrics Deployer
+  io.openshift.tags: metrics,deployer
+  vendor: Red Hat
+name: openshift3/metrics-deployer
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.5/openshift-enterprise-base-docker/config.yml
+++ b/groups/openshift-3.5/openshift-enterprise-base-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/base
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is the base image from which all OpenShift Container Platform
+    images inherit.
+  io.k8s.display-name: OpenShift Container Platform RHEL 7 Base
+  io.openshift.tags: openshift,base
+  vendor: Red Hat
+name: openshift3/ose-base
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.5/openshift-enterprise-deployer-docker/config.yml
+++ b/groups/openshift-3.5/openshift-enterprise-deployer-docker/config.yml
@@ -1,0 +1,19 @@
+content:
+  source:
+    alias: ose
+    path: images/deployer
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and executes
+    the user deployment process to roll out new containers. It may be used as a base
+    image for building your own custom deployer image.
+  io.k8s.display-name: OpenShift Container Platform Deployer
+  io.openshift.tags: openshift,deployer
+  vendor: Red Hat
+name: openshift3/ose-deployer
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.5/openshift-enterprise-docker-builder-docker/config.yml
+++ b/groups/openshift-3.5/openshift-enterprise-docker-builder-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/builder/docker/docker-builder
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and is responsible
+    for executing Docker image builds.
+  io.k8s.display-name: OpenShift Container Platform Docker Builder
+  io.openshift.tags: openshift,builder
+  vendor: Red Hat
+name: openshift3/ose-docker-builder
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.5/openshift-enterprise-docker/config.yml
+++ b/groups/openshift-3.5/openshift-enterprise-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/origin
+from:
+  member: openshift-enterprise-base-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: OpenShift Container Platform is a platform for developing, building,
+    and deploying containerized applications.
+  io.k8s.display-name: OpenShift Container Platform Application Platform
+  io.openshift.tags: openshift,core
+  vendor: Red Hat
+name: openshift3/ose
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.5/openshift-enterprise-dockerregistry-docker/config.yml
+++ b/groups/openshift-3.5/openshift-enterprise-dockerregistry-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/dockerregistry
+from:
+  member: openshift-enterprise-base-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component ofOpenShift Container Platform and exposes
+    a Docker registry that is integrated with the cluster for authentication and management.
+  io.k8s.display-name: OpenShift Container Platform Image Registry
+  io.openshift.tags: openshift,docker,registry
+  vendor: Red Hat
+name: openshift3/ose-docker-registry
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.5/openshift-enterprise-egress-router-docker/config.yml
+++ b/groups/openshift-3.5/openshift-enterprise-egress-router-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/egress/router
+from:
+  member: openshift-enterprise-base-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and contains
+    an egress router.
+  io.k8s.display-name: OpenShift Container Platform Egress Router
+  io.openshift.tags: openshift,router,egress
+  vendor: Red Hat
+name: openshift3/ose-egress-router
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.5/openshift-enterprise-haproxy-router-docker/config.yml
+++ b/groups/openshift-3.5/openshift-enterprise-haproxy-router-docker/config.yml
@@ -1,0 +1,20 @@
+content:
+  source:
+    alias: ose
+    path: images/router/haproxy
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and contains
+    an HAProxy instance that automatically exposes services within the cluster through
+    routes, and offers TLS termination, reencryption, or SNI-passthrough on ports
+    80 and 443.
+  io.k8s.display-name: OpenShift Container Platform HAProxy Router
+  io.openshift.tags: openshift,router,haproxy
+  vendor: Red Hat
+name: openshift3/ose-haproxy-router
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.5/openshift-enterprise-keepalived-ipfailover-docker/config.yml
+++ b/groups/openshift-3.5/openshift-enterprise-keepalived-ipfailover-docker/config.yml
@@ -1,0 +1,19 @@
+content:
+  source:
+    alias: ose
+    path: images/ipfailover/keepalived
+from:
+  member: openshift-enterprise-base-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and runs
+    a clustered keepalived instance across multiple hosts to allow highly available
+    IP addresses.
+  io.k8s.display-name: OpenShift Container Platform IP Failover
+  io.openshift.tags: openshift,ha,ip,failover
+  vendor: Red Hat
+name: openshift3/ose-keepalived-ipfailover
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.5/openshift-enterprise-node-docker/config.yml
+++ b/groups/openshift-3.5/openshift-enterprise-node-docker/config.yml
@@ -1,0 +1,19 @@
+content:
+  source:
+    alias: ose
+    path: images/node
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and contains
+    the software for individual nodes when using SDN.
+  io.k8s.display-name: OpenShift Container Platform Node
+  io.openshift.tags: openshift,node
+  vendor: Red Hat
+name: openshift3/node
+owners:
+- dgoodwin@redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.5/openshift-enterprise-openvswitch-docker/config.yml
+++ b/groups/openshift-3.5/openshift-enterprise-openvswitch-docker/config.yml
@@ -1,0 +1,19 @@
+content:
+  source:
+    alias: ose
+    path: images/openvswitch
+from:
+  member: openshift-enterprise-node-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and runs
+    an OpenVSwitch daemon process.
+  io.k8s.display-name: OpenShift Container Platform OpenVSwitch Daemon
+  io.openshift.tags: openshift,openvswitch
+  vendor: Red Hat
+name: openshift3/openvswitch
+owners:
+- sdodson@redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.5/openshift-enterprise-pod-docker/config.yml
+++ b/groups/openshift-3.5/openshift-enterprise-pod-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/pod
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and holds
+    on to the shared Linux namespaces within a Pod.
+  io.k8s.display-name: OpenShift Container Platform Pod Infrastructure
+  io.openshift.tags: openshift,pod
+  vendor: Red Hat
+name: openshift3/ose-pod rhel7/pod-infrastructure
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.5/openshift-enterprise-recycler-docker/config.yml
+++ b/groups/openshift-3.5/openshift-enterprise-recycler-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/recycler
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and is used
+    to prepare persistent volumes for reuse after they are deleted.
+  io.k8s.display-name: OpenShift Container Platform Volume Recycler
+  io.openshift.tags: openshift,recycler
+  vendor: Red Hat
+name: openshift3/ose-recycler
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.5/openshift-enterprise-sti-builder-docker/config.yml
+++ b/groups/openshift-3.5/openshift-enterprise-sti-builder-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/builder/docker/sti-builder
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and is responsible
+    for executing source-to-image (s2i) image builds.
+  io.k8s.display-name: OpenShift Container Platform S2I Builder
+  io.openshift.tags: openshift,sti,builder
+  vendor: Red Hat
+name: openshift3/ose-sti-builder
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.6/aos-f5-router-docker/config.yml
+++ b/groups/openshift-3.6/aos-f5-router-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/router/f5
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and programs
+    a BigIP F5 router to expose services within the cluster.
+  io.k8s.display-name: OpenShift Container Platform F5 Router
+  io.openshift.tags: openshift,router,f5
+  vendor: Red Hat
+name: openshift3/ose-f5-router
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.6/aos3-installation-docker/config.yml
+++ b/groups/openshift-3.6/aos3-installation-docker/config.yml
@@ -1,0 +1,19 @@
+content:
+  source:
+    alias: openshift-ansible
+    path: images/installer
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: A containerized openshift-ansible image to let you run playbooks
+    to install, upgrade, maintain and check an OpenShift cluster
+  io.k8s.display-name: openshift-ansible
+  io.openshift.tags: openshift,install,upgrade,ansible
+  vendor: Red Hat
+name: openshift3/ose-ansible
+owners:
+- dev@lists.openshift.redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.6/container-engine-docker/config.yml
+++ b/groups/openshift-3.6/container-engine-docker/config.yml
@@ -1,0 +1,13 @@
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  io.k8s.description: Container-engine is an open-source engine that automates the
+    / deployment of any application as a lightweight, portable, self-sufficient /
+    container that will run virtually anywhere
+  vendor: Red Hat
+name: openshift3/container-engine
+owners:
+- jhonce@redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.6/jenkins-slave-base-rhel7-docker/config.yml
+++ b/groups/openshift-3.6/jenkins-slave-base-rhel7-docker/config.yml
@@ -1,0 +1,21 @@
+content:
+  source:
+    alias: jenkins
+    path: slave-base
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: The jenkins slave base image is intended to be built on top
+    of, to add your own tools that your jenkins job needs. The slave base image includes
+    all the jenkins logic to operate as a slave, so users just have to yum install
+    any additional packages their specific jenkins job will need
+  io.k8s.display-name: Jenkins Slave Base
+  io.openshift.tags: openshift,jenkins,slave
+  vendor: Red Hat
+name: openshift3/jenkins-slave-base-rhel7
+owners:
+- bparees@redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.6/jenkins-slave-maven-rhel7-docker/config.yml
+++ b/groups/openshift-3.6/jenkins-slave-maven-rhel7-docker/config.yml
@@ -1,0 +1,19 @@
+content:
+  source:
+    alias: jenkins
+    path: slave-maven
+from:
+  member: jenkins-slave-base-rhel7-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: The jenkins slave maven image has the maven tools on top of
+    the jenkins slave base image.
+  io.k8s.display-name: Jenkins Slave Maven
+  io.openshift.tags: openshift,jenkins,slave,maven
+  vendor: Red Hat
+name: "openshift3/jenkins-slave-maven-rhel7"
+owners:
+- bparees@redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.6/jenkins-slave-nodejs-rhel7-docker/config.yml
+++ b/groups/openshift-3.6/jenkins-slave-nodejs-rhel7-docker/config.yml
@@ -1,0 +1,19 @@
+content:
+  source:
+    alias: jenkins
+    path: slave-nodejs
+from:
+  member: jenkins-slave-base-rhel7-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: The jenkins slave nodejs image has the nodejs tools on top of
+    the jenkins slave base image.
+  io.k8s.display-name: Jenkins Slave Nodejs
+  io.openshift.tags: openshift,jenkins,slave,nodejs
+  vendor: Red Hat
+name: openshift3/jenkins-slave-nodejs-rhel7
+owners:
+- bparees@redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.6/logging-auth-proxy-docker/config.yml
+++ b/groups/openshift-3.6/logging-auth-proxy-docker/config.yml
@@ -1,0 +1,13 @@
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Logging auth proxy
+  io.k8s.display-name: Logging auth proxy
+  vendor: Red Hat
+name: openshift3/logging-auth-proxy
+owners:
+- dev@lists.openshift.redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.6/logging-curator-docker/config.yml
+++ b/groups/openshift-3.6/logging-curator-docker/config.yml
@@ -1,0 +1,14 @@
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Curator elasticsearch container for elasticsearch deletion/archival
+  io.k8s.display-name: Curator 3.5.0-2
+  io.openshift.tags: logging,elk,elasticsearch,curator
+  vendor: Red Hat
+name: openshift3/logging-curator
+owners:
+- dev@lists.openshift.redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.6/logging-deployment-docker/config.yml
+++ b/groups/openshift-3.6/logging-deployment-docker/config.yml
@@ -1,0 +1,14 @@
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Deployer container for deploying the aggregated logging solution
+  io.k8s.display-name: Logging deployer
+  io.openshift.tags: logging,elk,fluentd
+  vendor: Red Hat
+name: openshift3/logging-deployer
+owners:
+- dev@lists.openshift.redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.6/logging-elasticsearch-docker/config.yml
+++ b/groups/openshift-3.6/logging-elasticsearch-docker/config.yml
@@ -1,0 +1,14 @@
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Elasticsearch container for EFK aggregated logging storage
+  io.k8s.display-name: Elasticsearch 2.4.4
+  io.openshift.tags: logging,elk,elasticsearch
+  vendor: Red Hat
+name: openshift3/logging-elasticsearch
+owners:
+- dev@lists.openshift.redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.6/logging-fluentd-docker/config.yml
+++ b/groups/openshift-3.6/logging-fluentd-docker/config.yml
@@ -1,0 +1,14 @@
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Fluentd container for collecting of docker container logs
+  io.k8s.display-name: Fluentd 0.12.39
+  io.openshift.tags: logging,elk,fluentd
+  vendor: Red Hat
+name: openshift3/logging-fluentd
+owners:
+- dev@lists.openshift.redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.6/logging-kibana-docker/config.yml
+++ b/groups/openshift-3.6/logging-kibana-docker/config.yml
@@ -1,0 +1,14 @@
+from:
+  image: rhscl/nodejs-6-rhel7
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Kibana container for querying Elasticsearch for aggregated logs
+  io.k8s.display-name: Kibana
+  io.openshift.tags: logging,elk,kibana
+  vendor: Red Hat
+name: openshift3/logging-kibana
+owners:
+- dev@lists.openshift.redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.6/metrics-cassandra-docker/config.yml
+++ b/groups/openshift-3.6/metrics-cassandra-docker/config.yml
@@ -1,0 +1,13 @@
+from:
+  image: jboss-base-7/jdk8:1.3-11
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Hawkular-Metrics Cassandra image for metrics collection.
+  io.k8s.display-name: Cassandra
+  io.openshift.tags: metrics,cassandra
+  vendor: Red Hat
+name: openshift3/metrics-cassandra
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.6/metrics-deployer-docker/config.yml
+++ b/groups/openshift-3.6/metrics-deployer-docker/config.yml
@@ -1,0 +1,13 @@
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Image to handle deploying all the metrics components.
+  io.k8s.display-name: Metrics Deployer
+  io.openshift.tags: metrics,deployer
+  vendor: Red Hat
+name: openshift3/metrics-deployer
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.6/metrics-hawkular-metrics-docker/config.yml
+++ b/groups/openshift-3.6/metrics-hawkular-metrics-docker/config.yml
@@ -1,0 +1,13 @@
+from:
+  image: jboss-eap-7/eap70-openshift:1.5
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Metric handling engine in OpenShift
+  io.k8s.display-name: Hawkular Metrics
+  io.openshift.tags: metrics,hawkular,hawkular-metrics
+  vendor: Red Hat
+name: openshift3/metrics-hawkular-metrics
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.6/metrics-hawkular-openshift-agent-docker/config.yml
+++ b/groups/openshift-3.6/metrics-hawkular-openshift-agent-docker/config.yml
@@ -1,0 +1,14 @@
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Application metrics collector.
+  io.k8s.display-name: Hawkular OpenShift Agent
+  io.openshift.tags: metrics,hawkular,hawkular-openshift-agent
+  vendor: Red Hat
+name: openshift3/metrics-hawkular-openshift-agent
+owners:
+- hawkular-dev@lists.jboss.org
+repo:
+  type: rpms

--- a/groups/openshift-3.6/metrics-heapster-docker/config.yml
+++ b/groups/openshift-3.6/metrics-heapster-docker/config.yml
@@ -1,0 +1,14 @@
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Heapster image for metrics collection.
+  io.k8s.display-name: Heapster
+  io.openshift.tags: metrics,heapster
+  vendor: Red Hat
+name: openshift3/metrics-heapster
+owners:
+- hawkular-dev@lists.jboss.org
+repo:
+  type: rpms

--- a/groups/openshift-3.6/openshift-enterprise-apb-base-docker/config.yml
+++ b/groups/openshift-3.6/openshift-enterprise-apb-base-docker/config.yml
@@ -1,0 +1,10 @@
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  vendor: Red Hat
+name: openshift3/apb-base
+owners:
+- Community
+repo:
+  type: rpms

--- a/groups/openshift-3.6/openshift-enterprise-asb-docker/config.yml
+++ b/groups/openshift-3.6/openshift-enterprise-asb-docker/config.yml
@@ -1,0 +1,10 @@
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  vendor: Red Hat
+name: openshift3/ose-ansible-service-broker
+owners:
+- Community
+repo:
+  type: rpms

--- a/groups/openshift-3.6/openshift-enterprise-base-docker/config.yml
+++ b/groups/openshift-3.6/openshift-enterprise-base-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/base
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is the base image from which all OpenShift Container Platform
+    images inherit.
+  io.k8s.display-name: OpenShift Container Platform RHEL 7 Base
+  io.openshift.tags: openshift,base
+  vendor: Red Hat
+name: openshift3/ose-base
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.6/openshift-enterprise-cluster-capacity-docker/config.yml
+++ b/groups/openshift-3.6/openshift-enterprise-cluster-capacity-docker/config.yml
@@ -1,0 +1,15 @@
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and runs
+    Cluster Capacity analysis tool.
+  io.k8s.display-name: OpenShift Container Platform Cluster Capacity
+  io.openshift.tags: openshift,cluster-capacity
+  vendor: Red Hat
+name: openshift3/ose-cluster-capacity
+owners:
+- avagarwa@redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.6/openshift-enterprise-deployer-docker/config.yml
+++ b/groups/openshift-3.6/openshift-enterprise-deployer-docker/config.yml
@@ -1,0 +1,19 @@
+content:
+  source:
+    alias: ose
+    path: images/deployer
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and executes
+    the user deployment process to roll out new containers. It may be used as a base
+    image for building your own custom deployer image.
+  io.k8s.display-name: OpenShift Container Platform Deployer
+  io.openshift.tags: openshift,deployer
+  vendor: Red Hat
+name: openshift3/ose-deployer
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.6/openshift-enterprise-docker-builder-docker/config.yml
+++ b/groups/openshift-3.6/openshift-enterprise-docker-builder-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/builder/docker/docker-builder
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and is responsible
+    for executing Docker image builds.
+  io.k8s.display-name: OpenShift Container Platform Docker Builder
+  io.openshift.tags: openshift,builder
+  vendor: Red Hat
+name: openshift3/ose-docker-builder
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.6/openshift-enterprise-docker/config.yml
+++ b/groups/openshift-3.6/openshift-enterprise-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/origin
+from:
+  member: openshift-enterprise-base-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: OpenShift Container Platform is a platform for developing, building,
+    and deploying containerized applications.
+  io.k8s.display-name: OpenShift Container Platform Application Platform
+  io.openshift.tags: openshift,core
+  vendor: Red Hat
+name: openshift3/ose
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.6/openshift-enterprise-dockerregistry-docker/config.yml
+++ b/groups/openshift-3.6/openshift-enterprise-dockerregistry-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/dockerregistry
+from:
+  member: openshift-enterprise-base-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and exposes
+    a Docker registry that is integrated with the cluster for authentication and management.
+  io.k8s.display-name: OpenShift Container Platform Image Registry
+  io.openshift.tags: openshift,docker,registry
+  vendor: Red Hat
+name: openshift3/ose-docker-registry
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.6/openshift-enterprise-egress-router-docker/config.yml
+++ b/groups/openshift-3.6/openshift-enterprise-egress-router-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/egress/router
+from:
+  member: openshift-enterprise-base-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Origin and contains an egress
+    router.
+  io.k8s.display-name: OpenShift Origin Egress Router
+  io.openshift.tags: openshift,router,egress
+  vendor: Red Hat
+name: openshift3/ose-egress-router
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.6/openshift-enterprise-federation-docker/config.yml
+++ b/groups/openshift-3.6/openshift-enterprise-federation-docker/config.yml
@@ -1,0 +1,14 @@
+from:
+  member: openshift-enterprise-base-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and contains
+    the software for running federation servers.
+  io.k8s.display-name: OpenShift Container Platform Federation
+  io.openshift.tags: openshift,federation
+  vendor: Red Hat
+name: openshift3/ose-federation
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.6/openshift-enterprise-haproxy-router-docker/config.yml
+++ b/groups/openshift-3.6/openshift-enterprise-haproxy-router-docker/config.yml
@@ -1,0 +1,20 @@
+content:
+  source:
+    alias: ose
+    path: images/router/haproxy
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and contains
+    an HAProxy instance that automatically exposes services within the cluster through
+    routes, and offers TLS termination, reencryption, or SNI-passthrough on ports
+    80 and 443.
+  io.k8s.display-name: OpenShift Container Platform HAProxy Router
+  io.openshift.tags: openshift,router,haproxy
+  vendor: Red Hat
+name: openshift3/ose-haproxy-router
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.6/openshift-enterprise-keepalived-ipfailover-docker/config.yml
+++ b/groups/openshift-3.6/openshift-enterprise-keepalived-ipfailover-docker/config.yml
@@ -1,0 +1,19 @@
+content:
+  source:
+    alias: ose
+    path: images/ipfailover/keepalived
+from:
+  member: openshift-enterprise-base-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and runs
+    a clustered keepalived instance across multiple hosts to allow highly available
+    IP addresses.
+  io.k8s.display-name: OpenShift Container Platform IP Failover
+  io.openshift.tags: openshift,ha,ip,failover
+  vendor: Red Hat
+name: openshift3/ose-keepalived-ipfailover
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.6/openshift-enterprise-mediawiki-docker/config.yml
+++ b/groups/openshift-3.6/openshift-enterprise-mediawiki-docker/config.yml
@@ -1,0 +1,9 @@
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  vendor: Red Hat
+name: openshift3/mediawiki-123
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.6/openshift-enterprise-mediawiki/config.yml
+++ b/groups/openshift-3.6/openshift-enterprise-mediawiki/config.yml
@@ -1,0 +1,10 @@
+from:
+  member: openshift-enterprise-apb-base-docker
+labels:
+  License: GPLv2+
+  vendor: Red Hat
+name: openshift3/mediawiki-apb
+owners:
+- Community
+repo:
+  type: apbs

--- a/groups/openshift-3.6/openshift-enterprise-node-docker/config.yml
+++ b/groups/openshift-3.6/openshift-enterprise-node-docker/config.yml
@@ -1,0 +1,19 @@
+content:
+  source:
+    alias: ose
+    path: images/node
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and contains
+    the software for individual nodes when using SDN.
+  io.k8s.display-name: OpenShift Container Platform Node
+  io.openshift.tags: openshift,node
+  vendor: Red Hat
+name: openshift3/node
+owners:
+- dgoodwin@redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.6/openshift-enterprise-openvswitch-docker/config.yml
+++ b/groups/openshift-3.6/openshift-enterprise-openvswitch-docker/config.yml
@@ -1,0 +1,19 @@
+content:
+  source:
+    alias: ose
+    path: images/openvswitch
+from:
+  member: openshift-enterprise-node-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and runs
+    an OpenVSwitch daemon process.
+  io.k8s.display-name: OpenShift Container Platform OpenVSwitch Daemon
+  io.openshift.tags: openshift,openvswitch
+  vendor: Red Hat
+name: openshift3/openvswitch
+owners:
+- sdodson@redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.6/openshift-enterprise-pod-docker/config.yml
+++ b/groups/openshift-3.6/openshift-enterprise-pod-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/pod
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and holds
+    on to the shared Linux namespaces within a Pod.
+  io.k8s.display-name: OpenShift Container Platform Pod Infrastructure
+  io.openshift.tags: openshift,pod
+  vendor: Red Hat
+name: openshift3/ose-pod rhel7/pod-infrastructure
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.6/openshift-enterprise-postgresql/config.yml
+++ b/groups/openshift-3.6/openshift-enterprise-postgresql/config.yml
@@ -1,0 +1,10 @@
+from:
+  member: openshift-enterprise-apb-base-docker
+labels:
+  License: GPLv2+
+  vendor: Red Hat
+name: openshift3/postgresql-apb
+owners:
+- Community
+repo:
+  type: apbs

--- a/groups/openshift-3.6/openshift-enterprise-recycler-docker/config.yml
+++ b/groups/openshift-3.6/openshift-enterprise-recycler-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/recycler
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and is used
+    to prepare persistent volumes for reuse after they are deleted.
+  io.k8s.display-name: OpenShift Container Platform Volume Recycler
+  io.openshift.tags: openshift,recycler
+  vendor: Red Hat
+name: openshift3/ose-recycler
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.6/openshift-enterprise-service-catalog-docker/config.yml
+++ b/groups/openshift-3.6/openshift-enterprise-service-catalog-docker/config.yml
@@ -1,0 +1,14 @@
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and runs
+    Service Catalog.
+  io.k8s.display-name: OpenShift Container Platform Service Catalog
+  io.openshift.tags: openshift,service-catalog
+  vendor: Red Hat
+name: openshift3/ose-service-catalog
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.6/openshift-enterprise-sti-builder-docker/config.yml
+++ b/groups/openshift-3.6/openshift-enterprise-sti-builder-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/builder/docker/sti-builder
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and is responsible
+    for executing source-to-image (s2i) image builds.
+  io.k8s.display-name: OpenShift Container Platform S2I Builder
+  io.openshift.tags: openshift,sti,builder
+  vendor: Red Hat
+name: openshift3/ose-sti-builder
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.6/openshift-jenkins-2-docker/config.yml
+++ b/groups/openshift-3.6/openshift-jenkins-2-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: jenkins
+    path: '2'
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Jenkins is a continuous integration server
+  io.k8s.display-name: Jenkins 2
+  io.openshift.tags: jenkins,jenkins2,ci
+  vendor: Red Hat
+name: openshift3/jenkins-2-rhel7
+owners:
+- bparees@redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.6/openshift-jenkins-docker/config.yml
+++ b/groups/openshift-3.6/openshift-jenkins-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: jenkins
+    path: '1'
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Jenkins is a continuous integration server
+  io.k8s.display-name: Jenkins 1.651.2
+  io.openshift.tags: jenkins,jenkins1,ci
+  vendor: Red Hat
+name: openshift3/jenkins-1-rhel7
+owners:
+- bparees@redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.6/ose-egress-http-proxy-docker/config.yml
+++ b/groups/openshift-3.6/ose-egress-http-proxy-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/egress/http-proxy
+from:
+  member: openshift-enterprise-base-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and contains
+    an egress http proxy.
+  io.k8s.display-name: OpenShift Container Platform Egress Http Proxy
+  io.openshift.tags: openshift,http-proxy,egress
+  vendor: Red Hat
+name: openshift3/ose-egress-http-proxy
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.6/registry-console-docker/config.yml
+++ b/groups/openshift-3.6/registry-console-docker/config.yml
@@ -1,0 +1,15 @@
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: The registry-console image provides a web console for the OpenShift
+    Container Platform stand-alone registry.
+  io.k8s.display-name: OpenShift Stand-Alone Registry Console
+  io.openshift.tags: openshift,docker,registry,console
+  vendor: Red Hat
+name: openshift3/registry-console
+owners:
+- dperpeet@redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.7/aos-f5-router-docker/config.yml
+++ b/groups/openshift-3.7/aos-f5-router-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/router/f5
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and programs
+    a BigIP F5 router to expose services within the cluster.
+  io.k8s.display-name: OpenShift Container Platform F5 Router
+  io.openshift.tags: openshift,router,f5
+  vendor: Red Hat
+name: openshift3/ose-f5-router
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.7/aos3-installation-docker/config.yml
+++ b/groups/openshift-3.7/aos3-installation-docker/config.yml
@@ -1,0 +1,19 @@
+content:
+  source:
+    alias: openshift-ansible
+    path: images/installer
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: A containerized openshift-ansible image to let you run playbooks
+    to install, upgrade, maintain and check an OpenShift cluster
+  io.k8s.display-name: openshift-ansible
+  io.openshift.tags: openshift,install,upgrade,ansible
+  vendor: Red Hat
+name: openshift3/ose-ansible
+owners:
+- dev@lists.openshift.redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.7/container-engine-docker/config.yml
+++ b/groups/openshift-3.7/container-engine-docker/config.yml
@@ -1,0 +1,13 @@
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  io.k8s.description: Container-engine is an open-source engine that automates the
+    / deployment of any application as a lightweight, portable, self-sufficient /
+    container that will run virtually anywhere
+  vendor: Red Hat
+name: openshift3/container-engine
+owners:
+- jhonce@redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.7/jenkins-slave-base-rhel7-docker/config.yml
+++ b/groups/openshift-3.7/jenkins-slave-base-rhel7-docker/config.yml
@@ -1,0 +1,21 @@
+content:
+  source:
+    alias: jenkins
+    path: slave-base
+from:
+  image: openshift3/ose:v3.7.0-0.125.0.0
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: The jenkins slave base image is intended to be built on top
+    of, to add your own tools that your jenkins job needs. The slave base image includes
+    all the jenkins logic to operate as a slave, so users just have to yum install
+    any additional packages their specific jenkins job will need
+  io.k8s.display-name: Jenkins Slave Base
+  io.openshift.tags: openshift,jenkins,slave
+  vendor: Red Hat
+name: openshift3/jenkins-slave-base-rhel7
+owners:
+- bparees@redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.7/jenkins-slave-maven-rhel7-docker/config.yml
+++ b/groups/openshift-3.7/jenkins-slave-maven-rhel7-docker/config.yml
@@ -1,0 +1,19 @@
+content:
+  source:
+    alias: jenkins
+    path: slave-maven
+from:
+  member: jenkins-slave-base-rhel7-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: The jenkins slave maven image has the maven tools on top of
+    the jenkins slave base image.
+  io.k8s.display-name: Jenkins Slave Maven
+  io.openshift.tags: openshift,jenkins,slave,maven
+  vendor: Red Hat
+name: "openshift3/jenkins-slave-maven-rhel7"
+owners:
+- bparees@redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.7/jenkins-slave-nodejs-rhel7-docker/config.yml
+++ b/groups/openshift-3.7/jenkins-slave-nodejs-rhel7-docker/config.yml
@@ -1,0 +1,19 @@
+content:
+  source:
+    alias: jenkins
+    path: slave-nodejs
+from:
+  member: jenkins-slave-base-rhel7-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: The jenkins slave nodejs image has the nodejs tools on top of
+    the jenkins slave base image.
+  io.k8s.display-name: Jenkins Slave Nodejs
+  io.openshift.tags: openshift,jenkins,slave,nodejs
+  vendor: Red Hat
+name: openshift3/jenkins-slave-nodejs-rhel7
+owners:
+- bparees@redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.7/logging-auth-proxy-docker/config.yml
+++ b/groups/openshift-3.7/logging-auth-proxy-docker/config.yml
@@ -1,0 +1,13 @@
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Logging auth proxy
+  io.k8s.display-name: Logging auth proxy
+  vendor: Red Hat
+name: openshift3/logging-auth-proxy
+owners:
+- dev@lists.openshift.redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.7/logging-curator-docker/config.yml
+++ b/groups/openshift-3.7/logging-curator-docker/config.yml
@@ -1,0 +1,14 @@
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Curator elasticsearch container for elasticsearch deletion/archival
+  io.k8s.display-name: Curator 3.5.0-2
+  io.openshift.tags: logging,elk,elasticsearch,curator
+  vendor: Red Hat
+name: openshift3/logging-curator
+owners:
+- dev@lists.openshift.redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.7/logging-deployment-docker/config.yml
+++ b/groups/openshift-3.7/logging-deployment-docker/config.yml
@@ -1,0 +1,14 @@
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Deployer container for deploying the aggregated logging solution
+  io.k8s.display-name: Logging deployer
+  io.openshift.tags: logging,elk,fluentd
+  vendor: Red Hat
+name: openshift3/logging-deployer
+owners:
+- dev@lists.openshift.redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.7/logging-elasticsearch-docker/config.yml
+++ b/groups/openshift-3.7/logging-elasticsearch-docker/config.yml
@@ -1,0 +1,14 @@
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Elasticsearch container for EFK aggregated logging storage
+  io.k8s.display-name: Elasticsearch 2.4.4
+  io.openshift.tags: logging,elk,elasticsearch
+  vendor: Red Hat
+name: openshift3/logging-elasticsearch
+owners:
+- dev@lists.openshift.redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.7/logging-fluentd-docker/config.yml
+++ b/groups/openshift-3.7/logging-fluentd-docker/config.yml
@@ -1,0 +1,14 @@
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Fluentd container for collecting of docker container logs
+  io.k8s.display-name: Fluentd 0.12.39
+  io.openshift.tags: logging,elk,fluentd
+  vendor: Red Hat
+name: openshift3/logging-fluentd
+owners:
+- dev@lists.openshift.redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.7/logging-kibana-docker/config.yml
+++ b/groups/openshift-3.7/logging-kibana-docker/config.yml
@@ -1,0 +1,14 @@
+from:
+  image: rhscl/nodejs-6-rhel7
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Kibana container for querying Elasticsearch for aggregated logs
+  io.k8s.display-name: Kibana
+  io.openshift.tags: logging,elk,kibana
+  vendor: Red Hat
+name: openshift3/logging-kibana
+owners:
+- dev@lists.openshift.redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.7/metrics-cassandra-docker/config.yml
+++ b/groups/openshift-3.7/metrics-cassandra-docker/config.yml
@@ -1,0 +1,13 @@
+from:
+  image: jboss-base-7/jdk8:1.3-11
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Hawkular-Metrics Cassandra image for metrics collection.
+  io.k8s.display-name: Cassandra
+  io.openshift.tags: metrics,cassandra
+  vendor: Red Hat
+name: openshift3/metrics-cassandra
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.7/metrics-deployer-docker/config.yml
+++ b/groups/openshift-3.7/metrics-deployer-docker/config.yml
@@ -1,0 +1,13 @@
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Image to handle deploying all the metrics components.
+  io.k8s.display-name: Metrics Deployer
+  io.openshift.tags: metrics,deployer
+  vendor: Red Hat
+name: openshift3/metrics-deployer
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.7/metrics-hawkular-metrics-docker/config.yml
+++ b/groups/openshift-3.7/metrics-hawkular-metrics-docker/config.yml
@@ -1,0 +1,13 @@
+from:
+  image: jboss-eap-7/eap70-openshift:1.4
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Metric handling engine in OpenShift
+  io.k8s.display-name: Hawkular Metrics
+  io.openshift.tags: metrics,hawkular,hawkular-metrics
+  vendor: Red Hat
+name: openshift3/metrics-hawkular-metrics
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.7/metrics-hawkular-openshift-agent-docker/config.yml
+++ b/groups/openshift-3.7/metrics-hawkular-openshift-agent-docker/config.yml
@@ -1,0 +1,14 @@
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Application metrics collector.
+  io.k8s.display-name: Hawkular OpenShift Agent
+  io.openshift.tags: metrics,hawkular,hawkular-openshift-agent
+  vendor: Red Hat
+name: openshift3/metrics-hawkular-openshift-agent
+owners:
+- hawkular-dev@lists.jboss.org
+repo:
+  type: rpms

--- a/groups/openshift-3.7/metrics-heapster-docker/config.yml
+++ b/groups/openshift-3.7/metrics-heapster-docker/config.yml
@@ -1,0 +1,14 @@
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Heapster image for metrics collection.
+  io.k8s.display-name: Heapster
+  io.openshift.tags: metrics,heapster
+  vendor: Red Hat
+name: openshift3/metrics-heapster
+owners:
+- hawkular-dev@lists.jboss.org
+repo:
+  type: rpms

--- a/groups/openshift-3.7/openshift-enterprise-apb-base-docker/config.yml
+++ b/groups/openshift-3.7/openshift-enterprise-apb-base-docker/config.yml
@@ -1,0 +1,10 @@
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  vendor: Red Hat
+name: openshift3/apb-base
+owners:
+- Community
+repo:
+  type: rpms

--- a/groups/openshift-3.7/openshift-enterprise-asb-docker/config.yml
+++ b/groups/openshift-3.7/openshift-enterprise-asb-docker/config.yml
@@ -1,0 +1,10 @@
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  vendor: Red Hat
+name: openshift3/ose-ansible-service-broker
+owners:
+- Community
+repo:
+  type: rpms

--- a/groups/openshift-3.7/openshift-enterprise-cluster-capacity-docker/config.yml
+++ b/groups/openshift-3.7/openshift-enterprise-cluster-capacity-docker/config.yml
@@ -1,0 +1,15 @@
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and runs
+    Cluster Capacity analysis tool.
+  io.k8s.display-name: OpenShift Container Platform Cluster Capacity
+  io.openshift.tags: openshift,cluster-capacity
+  vendor: Red Hat
+name: openshift3/ose-cluster-capacity
+owners:
+- avagarwa@redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.7/openshift-enterprise-deployer-docker/config.yml
+++ b/groups/openshift-3.7/openshift-enterprise-deployer-docker/config.yml
@@ -1,0 +1,19 @@
+content:
+  source:
+    alias: ose
+    path: images/deployer
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and executes
+    the user deployment process to roll out new containers. It may be used as a base
+    image for building your own custom deployer image.
+  io.k8s.display-name: OpenShift Container Platform Deployer
+  io.openshift.tags: openshift,deployer
+  vendor: Red Hat
+name: openshift3/ose-deployer
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.7/openshift-enterprise-docker-builder-docker/config.yml
+++ b/groups/openshift-3.7/openshift-enterprise-docker-builder-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/builder/docker/docker-builder
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and is responsible
+    for executing Docker image builds.
+  io.k8s.display-name: OpenShift Container Platform Docker Builder
+  io.openshift.tags: openshift,builder
+  vendor: Red Hat
+name: openshift3/ose-docker-builder
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.7/openshift-enterprise-dockerregistry-docker/config.yml
+++ b/groups/openshift-3.7/openshift-enterprise-dockerregistry-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/dockerregistry
+from:
+  member: openshift-enterprise-base-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and exposes
+    a Docker registry that is integrated with the cluster for authentication and management.
+  io.k8s.display-name: OpenShift Container Platform Image Registry
+  io.openshift.tags: openshift,docker,registry
+  vendor: Red Hat
+name: openshift3/ose-docker-registry
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.7/openshift-enterprise-egress-router-docker/config.yml
+++ b/groups/openshift-3.7/openshift-enterprise-egress-router-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/egress/router
+from:
+  member: openshift-enterprise-base-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Origin and contains an egress
+    router.
+  io.k8s.display-name: OpenShift Origin Egress Router
+  io.openshift.tags: openshift,router,egress
+  vendor: Red Hat
+name: openshift3/ose-egress-router
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.7/openshift-enterprise-federation-docker/config.yml
+++ b/groups/openshift-3.7/openshift-enterprise-federation-docker/config.yml
@@ -1,0 +1,14 @@
+from:
+  member: openshift-enterprise-base-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and contains
+    the software for running federation servers.
+  io.k8s.display-name: OpenShift Container Platform Federation
+  io.openshift.tags: openshift,federation
+  vendor: Red Hat
+name: openshift3/ose-federation
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.7/openshift-enterprise-haproxy-router-docker/config.yml
+++ b/groups/openshift-3.7/openshift-enterprise-haproxy-router-docker/config.yml
@@ -1,0 +1,20 @@
+content:
+  source:
+    alias: ose
+    path: images/router/haproxy
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and contains
+    an HAProxy instance that automatically exposes services within the cluster through
+    routes, and offers TLS termination, reencryption, or SNI-passthrough on ports
+    80 and 443.
+  io.k8s.display-name: OpenShift Container Platform HAProxy Router
+  io.openshift.tags: openshift,router,haproxy
+  vendor: Red Hat
+name: openshift3/ose-haproxy-router
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.7/openshift-enterprise-keepalived-ipfailover-docker/config.yml
+++ b/groups/openshift-3.7/openshift-enterprise-keepalived-ipfailover-docker/config.yml
@@ -1,0 +1,19 @@
+content:
+  source:
+    alias: ose
+    path: images/ipfailover/keepalived
+from:
+  member: openshift-enterprise-base-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and runs
+    a clustered keepalived instance across multiple hosts to allow highly available
+    IP addresses.
+  io.k8s.display-name: OpenShift Container Platform IP Failover
+  io.openshift.tags: openshift,ha,ip,failover
+  vendor: Red Hat
+name: openshift3/ose-keepalived-ipfailover
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.7/openshift-enterprise-mediawiki-docker/config.yml
+++ b/groups/openshift-3.7/openshift-enterprise-mediawiki-docker/config.yml
@@ -1,0 +1,9 @@
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  vendor: Red Hat
+name: openshift3/mediawiki-123
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.7/openshift-enterprise-mediawiki/config.yml
+++ b/groups/openshift-3.7/openshift-enterprise-mediawiki/config.yml
@@ -1,0 +1,10 @@
+from:
+  member: openshift-enterprise-apb-base-docker
+labels:
+  License: GPLv2+
+  vendor: Red Hat
+name: openshift3/mediawiki-apb
+owners:
+- Community
+repo:
+  type: apbs

--- a/groups/openshift-3.7/openshift-enterprise-openvswitch-docker/config.yml
+++ b/groups/openshift-3.7/openshift-enterprise-openvswitch-docker/config.yml
@@ -1,0 +1,19 @@
+content:
+  source:
+    alias: ose
+    path: images/openvswitch
+from:
+  member: openshift-enterprise-node-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and runs
+    an OpenVSwitch daemon process.
+  io.k8s.display-name: OpenShift Container Platform OpenVSwitch Daemon
+  io.openshift.tags: openshift,openvswitch
+  vendor: Red Hat
+name: openshift3/openvswitch
+owners:
+- sdodson@redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.7/openshift-enterprise-pod-docker/config.yml
+++ b/groups/openshift-3.7/openshift-enterprise-pod-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/pod
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and holds
+    on to the shared Linux namespaces within a Pod.
+  io.k8s.display-name: OpenShift Container Platform Pod Infrastructure
+  io.openshift.tags: openshift,pod
+  vendor: Red Hat
+name: openshift3/ose-pod rhel7/pod-infrastructure
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.7/openshift-enterprise-postgresql/config.yml
+++ b/groups/openshift-3.7/openshift-enterprise-postgresql/config.yml
@@ -1,0 +1,10 @@
+from:
+  member: openshift-enterprise-apb-base-docker
+labels:
+  License: GPLv2+
+  vendor: Red Hat
+name: openshift3/postgresql-apb
+owners:
+- Community
+repo:
+  type: apbs

--- a/groups/openshift-3.7/openshift-enterprise-recycler-docker/config.yml
+++ b/groups/openshift-3.7/openshift-enterprise-recycler-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/recycler
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and is used
+    to prepare persistent volumes for reuse after they are deleted.
+  io.k8s.display-name: OpenShift Container Platform Volume Recycler
+  io.openshift.tags: openshift,recycler
+  vendor: Red Hat
+name: openshift3/ose-recycler
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.7/openshift-enterprise-service-catalog-docker/config.yml
+++ b/groups/openshift-3.7/openshift-enterprise-service-catalog-docker/config.yml
@@ -1,0 +1,14 @@
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and runs
+    Service Catalog.
+  io.k8s.display-name: OpenShift Container Platform Service Catalog
+  io.openshift.tags: openshift,service-catalog
+  vendor: Red Hat
+name: openshift3/ose-service-catalog
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.7/openshift-enterprise-sti-builder-docker/config.yml
+++ b/groups/openshift-3.7/openshift-enterprise-sti-builder-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/builder/docker/sti-builder
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and is responsible
+    for executing source-to-image (s2i) image builds.
+  io.k8s.display-name: OpenShift Container Platform S2I Builder
+  io.openshift.tags: openshift,sti,builder
+  vendor: Red Hat
+name: openshift3/ose-sti-builder
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.7/openshift-jenkins-2-docker/config.yml
+++ b/groups/openshift-3.7/openshift-jenkins-2-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: jenkins
+    path: '2'
+from:
+  member: openshift-enterprise-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: Jenkins is a continuous integration server
+  io.k8s.display-name: Jenkins 2.46
+  io.openshift.tags: jenkins,jenkins2,ci
+  vendor: Red Hat
+name: openshift3/jenkins-2-rhel7
+owners:
+- bparees@redhat.com
+repo:
+  type: rpms

--- a/groups/openshift-3.7/ose-egress-http-proxy-docker/config.yml
+++ b/groups/openshift-3.7/ose-egress-http-proxy-docker/config.yml
@@ -1,0 +1,18 @@
+content:
+  source:
+    alias: ose
+    path: images/egress/http-proxy
+from:
+  member: openshift-enterprise-base-docker
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: This is a component of OpenShift Container Platform and contains
+    an egress http proxy.
+  io.k8s.display-name: OpenShift Container Platform Egress Http Proxy
+  io.openshift.tags: openshift,http-proxy,egress
+  vendor: Red Hat
+name: openshift3/ose-egress-http-proxy
+owners: []
+repo:
+  type: rpms

--- a/groups/openshift-3.7/registry-console-docker/config.yml
+++ b/groups/openshift-3.7/registry-console-docker/config.yml
@@ -1,0 +1,15 @@
+from:
+  stream: rhel
+labels:
+  License: GPLv2+
+  architecture: x86_64
+  io.k8s.description: The registry-console image provides a web console for the OpenShift
+    Container Platform stand-alone registry.
+  io.k8s.display-name: OpenShift Stand-Alone Registry Console
+  io.openshift.tags: openshift,docker,registry,console
+  vendor: Red Hat
+name: openshift3/registry-console
+owners:
+- dperpeet@redhat.com
+repo:
+  type: rpms

--- a/oit/packages/runtime.py
+++ b/oit/packages/runtime.py
@@ -31,7 +31,7 @@ class Runtime(object):
     # Serialize access to the debug_log and console
     log_lock = Lock()
 
-    def __init__(self, metadata_dir, working_dir, group, branch, user, verbose):
+    def __init__(self, metadata_dir, working_dir, group, branch, user=None, verbose=False):
         self._verbose = verbose
         self.metadata_dir = metadata_dir
         self.working_dir = working_dir

--- a/oit/util/ose_conf_load.py
+++ b/oit/util/ose_conf_load.py
@@ -1,0 +1,171 @@
+import subprocess
+import sys
+import json
+import yaml
+import os
+import tempfile
+import urllib
+import dockerfile_parse
+
+cur_dir = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
+
+
+def resolve_none(val):
+    return val if val != 'None' else None
+
+
+def proc_image_type(val):
+    result = resolve_none(val)
+    if not result:
+        result = 'rpms'
+    return result
+
+
+def proc_image_from(val):
+    vals = val.split(' ')
+    vals = [resolve_none(v) for v in vals]
+    return {
+        'from': vals[0],
+        'dependency': vals[1],
+    }
+
+
+def proc_git_compare(val):
+    vals = val.split(' ')
+    vals = [resolve_none(v) for v in vals]
+    return {
+        'repo': vals[0],
+        'path': vals[1],
+        'dockerfile': vals[2],
+        'style': vals[3],
+    }
+
+
+def proc_image_name(val):
+    return resolve_none(val)
+
+
+def proc_image_tags(val):
+    return [resolve_none(v) for v in val.split(' ')]
+
+
+sub_dicts = {
+    'dict_image_type': proc_image_type,
+    'dict_image_from': proc_image_from,
+    'dict_git_compare': proc_git_compare,
+    'dict_image_name': proc_image_name,
+    'dict_image_tags': proc_image_tags,
+}
+
+out_dir = sys.argv[1]
+branch = sys.argv[2]
+version = branch.split('-')[2]
+ose_conf_path = sys.argv[3]
+group = 'base' if len(sys.argv) < 5 else sys.argv[4]
+
+data = subprocess.check_output([os.path.join(cur_dir, 'ose_conf_load.sh'), version, ose_conf_path])
+data = json.loads(data)
+
+ose_conf = {}
+
+for d in sub_dicts.keys():
+    base = d.replace('dict_', '')
+    for name, val in data[d].items():
+        if name not in ose_conf:
+            ose_conf[name] = {}
+            ose_conf[name]['image_type'] = 'rpms'
+        ose_conf[name][base] = sub_dicts[d](val)
+
+ose_images_path = ose_conf_path.replace('ose.conf', 'ose_images.sh')
+group_images = subprocess.check_output(
+    (ose_images_path + ' test --branch ' +
+     branch + ' --group base').split(' '))
+group_images = group_images.replace('\t', ' ')
+print(group_images)
+group_images = [img.split(' ')[1] for img in group_images.splitlines()]
+
+member_images = list(ose_conf.keys())
+
+dockerfile_base_url = 'http://pkgs.devel.redhat.com/cgit/{}/{}/plain/Dockerfile?h={}'
+tmp_dir = tempfile.mkdtemp()
+
+dockerfiles = {}
+print('Fetching Dockerfiles')
+for img in group_images:
+    img_type = ose_conf[img]['image_type']
+    df = os.path.join(tmp_dir, img + '.Dockerfile')
+    dockerfiles[img] = df
+    url = dockerfile_base_url.format(img_type, img, branch)
+    print('Downloading {} to\n{}\n'.format(url, df))
+    urllib.urlretrieve(url, df)
+
+req_labels = [
+    'vendor',
+    'License',
+    'architecture',
+    'io.k8s.display-name',
+    'io.k8s.description',
+    'io.openshift.tags'
+]
+for img, df in dockerfiles.items():
+    print(df)
+    dfp = dockerfile_parse.DockerfileParser(path=df)
+    # print(ose_conf[img])
+    ose = ose_conf[img]
+    config = {
+        'repo': {
+            'type': ose['image_type']
+        },
+        'name': ose['image_name'] or dfp.labels['name'],
+        'content': {
+            'source': {}
+        },
+        'from': {},
+        'labels': {
+            'vendor': 'Red Hat',
+            'License': 'GPLv2+'
+        },
+        'owners': []
+    }
+
+    if ose['image_from']['dependency'] in group_images:
+        config['from'] = {'member': ose['image_from']['dependency']}
+    elif (ose['image_from']['dependency'] is None and
+          ose['image_from']['from'] == 'rhel' and
+          dfp.baseimage.startswith('rhel')):
+            config['from']['stream'] = 'rhel'
+    elif dfp.baseimage.startswith('rhel7'):
+        config['from']['stream'] = 'rhel'
+    else:
+        config['from']['image'] = dfp.baseimage
+
+    if ose['git_compare'].get('path', None):
+        path_split = ose['git_compare']['path'].split('/')
+        config['content']['source']['alias'] = path_split[0]
+        config['content']['source']['path'] = '/'.join(path_split[1:])
+    else:
+        del config['content']
+
+    lbls = config['labels']
+    for l in req_labels:
+        if l in dfp.labels:
+            lbls[l] = dfp.labels[l]
+
+    if 'maintainer' in dfp.labels:
+        config['owners'].append(dfp.labels['maintainer'].split(' ')[-1].strip('<>'))
+    else:
+        with open(df, 'r') as dff:
+            lines = dff.readlines()
+            for line in lines:
+                if line.strip().startswith('MAINTAINER'):
+                    config['owners'].append(line.strip().split(' ')[-1].strip('<>'))
+                    break
+
+    cfg_dir = os.path.join(out_dir, img)
+    if not os.path.isdir(cfg_dir):
+        os.mkdir(cfg_dir)
+    cfg_yml = os.path.join(cfg_dir, 'config.yml')
+
+    with open(cfg_yml, 'w') as cfg_file:
+        print('Writing ' + cfg_yml)
+        yaml.safe_dump(config, cfg_file, indent=2, default_flow_style=False)

--- a/oit/util/ose_conf_load.sh
+++ b/oit/util/ose_conf_load.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+export MAJOR_RELEASE="$1"
+source "$2"
+
+assoc2json() {
+    declare -n v=$1
+    printf '%s\0' "${!v[@]}" "${v[@]}" |
+    jq -Rs 'split("\u0000") | . as $v | (length / 2) as $n | reduce range($n) as $idx ({}; .[$v[$idx]]=$v[$idx+$n])'
+}
+
+echo '{' # begin file
+
+echo '  "dict_image_type": '
+assoc2json dict_image_type
+echo ','
+
+echo '  "dict_image_from": '
+assoc2json dict_image_from
+echo ','
+
+echo '  "dict_git_compare": '
+assoc2json dict_git_compare
+echo ','
+
+echo '  "dict_image_name": '
+assoc2json dict_image_name
+echo ','
+
+echo '  "dict_image_tags": '
+assoc2json dict_image_tags
+
+echo '}' # end file


### PR DESCRIPTION
As this will likely only be used a couple times I didn't do a lot of fancy arg parsing...
```
python ose_conf_load <output_dir> rhaos-3.6-rhel-7 <ose.conf path>
```

Currently generates the following:
```yaml
content:
  source:
    alias: ose
    path: images/node
from:
  member: openshift-enterprise-docker
labels:
  License: GPLv2+
  architecture: x86_64
  io.k8s.description: This is a component of OpenShift Container Platform and contains
    the software for individual nodes when using SDN.
  io.k8s.display-name: OpenShift Container Platform Node
  io.openshift.tags: openshift,node
  vendor: Red Hat
name: openshift3/node
owners:
- dgoodwin@redhat.com
repo:
  type: rpms

```